### PR TITLE
Let file name be more visible on tabs

### DIFF
--- a/themes/sourc-color-theme.json
+++ b/themes/sourc-color-theme.json
@@ -72,7 +72,7 @@
     "tab.activeForeground": "#00b0df",
     "tab.border": "#00141d",
     "tab.inactiveBackground": "#002e3d",
-    "tab.inactiveForeground": "#00627e",
+    "tab.inactiveForeground": "#0081a5",
     "tab.unfocusedActiveForeground": "#00627e",
     "tab.unfocusedInactiveForeground": "#00485e",
     "editor.background": "#00141d",


### PR DESCRIPTION
Related to issue: https://github.com/vitormalencar/sourc/issues/8

Before:
![Captura de tela de 2020-10-06 22-04-53](https://user-images.githubusercontent.com/10124552/95275858-06bda680-0820-11eb-8123-8f6bd30f7b14.png)

After:
![Captura de tela de 2020-10-06 22-05-00](https://user-images.githubusercontent.com/10124552/95275860-09200080-0820-11eb-9bc2-c785c5aa40bd.png)
