### PR TITLE
Color contrast when select word

### DIFF
--- a/themes/sourc-color-theme.json
+++ b/themes/sourc-color-theme.json
@@ -5,7 +5,7 @@
     "focusBorder": "#ff963b",
     "foreground": "#00caff",
     "widget.shadow": "#00141d",
-    "selection.background": "#00485e",
+    "selection.background": "#ba90ff4c",
     "errorForeground": "#ff5b6f",
     "button.background": "#ff5d94",
     "button.foreground": "#00141d",


### PR DESCRIPTION
closes #11 

Before:
![Captura de tela de 2020-10-06 21-32-03](https://user-images.githubusercontent.com/10124552/95274255-af1d3c00-081b-11eb-9cc2-b4510aca3f30.png)

After:
![Captura de tela de 2020-10-06 21-31-46](https://user-images.githubusercontent.com/10124552/95274257-b2b0c300-081b-11eb-8a9c-340979701837.png)

My first idea was to set orange as the selected color, but the contrast between the background color and text color wasnt good, and it seems that vscode doesn't allow us to change the text color when it is selected. So, the better way was to change the selected color to make it possible to see what word is selected.

I think it only affects selected words on search (ctrl + f) and when you rename files.
